### PR TITLE
Add deployment workflow for Heroku and create Procfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to Heroku
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [test]  # Wait for tests to pass first
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build project
+        run: yarn build
+
+      - name: Deploy to Heroku
+        uses: akhileshns/heroku-deploy@v4.0.6
+        with:
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}
+          buildpack: heroku/nodejs

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start:prod


### PR DESCRIPTION
This pull request introduces a new deployment workflow for the project, specifically targeting Heroku. The key changes include setting up a GitHub Actions workflow to automate the deployment process and updating the `Procfile` to define the web process.

Deployment automation:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R34): Created a new GitHub Actions workflow named "Deploy to Heroku" that triggers on pushes to the `main` branch. This workflow includes steps for checking out the code, setting up Node.js, installing dependencies, building the project, and deploying to Heroku.

Process definition:

* [`Procfile`](diffhunk://#diff-0a99231995da379e7aebabe76c9d849a23737a42c3b3a8994043e2aa80958424R1): Added a new entry to define the web process, specifying that it should use `yarn start:prod` to start the application in production mode.