### PR TITLE
Set global API prefix and update Swagger documentation endpoint

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,14 +7,20 @@ import { ValidationPipe } from '@nestjs/common';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  app.setGlobalPrefix('api/v1', {
+    exclude: ['docs'], 
+  });
+  
   // Swagger configuration
   const config = new DocumentBuilder()
     .setTitle('Service Sphere API Documentation')
-    .setDescription('We hope that this API documentation will help you understand the Service Sphere API and not wonder why does life even matter.')
+    .setDescription(
+      'We hope that this API documentation will help you understand the Service Sphere API and not wonder why does life even matter.',
+    )
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('docs', app, document);
 
   app.useGlobalPipes(new ValidationPipe());
 


### PR DESCRIPTION
This pull request includes changes to the `src/main.ts` file to improve the API structure and documentation setup. The most important changes include setting a global prefix for the API routes, updating the Swagger documentation setup, and modifying the description format for better readability.

API structure improvements:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR10-R23): Set a global prefix for the API routes to `api/v1` and excluded the `docs` route from this prefix.

Documentation setup updates:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR10-R23): Changed the Swagger documentation route from `api` to `docs` for better clarity.
* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR10-R23): Modified the Swagger documentation description format for improved readability.