### PR TITLE
Refactor services to return jsend formatted responses; update control…

### DIFF
--- a/src/services/services.controller.spec.ts
+++ b/src/services/services.controller.spec.ts
@@ -48,10 +48,14 @@ describe('ServicesController', () => {
         },
       ];
 
-      jest.spyOn(service, 'getAllServices').mockResolvedValue(mockServices);
+      jest.spyOn(service, 'getAllServices').mockResolvedValue({
+        status: 'success',
+        data: mockServices,
+      });
 
       const result = await controller.getAllServices();
-      expect(result).toEqual(mockServices);
+      expect(result.status).toBe('success');
+      expect(result.data).toEqual(mockServices);
     });
   });
 
@@ -69,9 +73,13 @@ describe('ServicesController', () => {
         service_provider_id: new Types.ObjectId('67976faae068d60c62500837'),
       };
       const mockFiles = [];
-      jest.spyOn(service, 'createService').mockResolvedValue(mockServiceDto);
+      jest.spyOn(service, 'createService').mockResolvedValue({
+        status: 'success',
+        data: mockServiceDto,
+      });
       const result = await controller.createService({} as any, mockFiles);
-      expect(result).toEqual(mockServiceDto);
+      expect(result.status).toBe('success');
+      expect(result.data).toEqual(mockServiceDto);
     });
   });
 
@@ -88,9 +96,13 @@ describe('ServicesController', () => {
         images: ['http://example.com/image3.png'],
         service_provider_id: new Types.ObjectId('67976faae068d60c62500838'),
       };
-      jest.spyOn(service, 'deleteService').mockResolvedValue(mockDeletedService);
+      jest.spyOn(service, 'deleteService').mockResolvedValue({
+        status: 'success',
+        data: mockDeletedService,
+      });
       const result = await controller.deleteService('fake-id');
-      expect(result).toEqual(mockDeletedService);
+      expect(result.status).toBe('success');
+      expect(result.data).toEqual(mockDeletedService);
     });
   });
 });

--- a/src/services/services.controller.ts
+++ b/src/services/services.controller.ts
@@ -1,12 +1,24 @@
-import { Controller, Get, Post, Body, UseInterceptors, UploadedFiles, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  UseInterceptors,
+  UploadedFiles,
+  Param,
+  Delete,
+} from '@nestjs/common';
 import { ServicesService } from './services.service';
-import { ApiTags, ApiOperation, ApiResponse, ApiConsumes } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiConsumes,
+} from '@nestjs/swagger';
 import { ServiceDto } from './dto/service.dto';
-import { CreateServiceDto } from './dto/create-service.dto'
+import { CreateServiceDto } from './dto/create-service.dto';
 import { ServiceInterface } from './interfaces/service.interface';
 import { FilesInterceptor } from '@nestjs/platform-express';
-;
-
 @ApiTags('Services')
 @Controller('services')
 export class ServicesController {
@@ -14,28 +26,39 @@ export class ServicesController {
 
   @Get()
   @ApiOperation({ summary: 'Retrieve all services' })
-  @ApiResponse({ status: 200, description: 'List of services', type: [ServiceDto] })
-  async getAllServices(): Promise<ServiceInterface[]> {
+  @ApiResponse({ status: 200, description: 'List of services' })
+  async getAllServices(): Promise<{
+    status: string;
+    data: ServiceInterface[];
+  }> {
     return this.servicesService.getAllServices();
   }
 
- @Post()
+  @Post()
   @UseInterceptors(FilesInterceptor('images'))
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: 'Create a new service with images' })
-  @ApiResponse({ status: 201, description: 'The service has been successfully created.', type: ServiceDto })
+  @ApiResponse({
+    status: 201,
+    description: 'The service has been successfully created.',
+    type: ServiceDto,
+  })
   async createService(
     @Body() createServiceDto: CreateServiceDto,
     @UploadedFiles() files: Express.Multer.File[],
-  ): Promise<ServiceInterface> {
+  ): Promise<{ status: string; data: ServiceInterface }> {
     return this.servicesService.createService(createServiceDto, files);
   }
 
   @ApiOperation({ summary: 'Delete a service by Id' })
-  @ApiResponse({ status: 200, description: 'The service deleted will be returned' })
+  @ApiResponse({
+    status: 200,
+    description: 'The service deleted will be returned',
+  })
   @Delete(':id')
-  async deleteService(@Param('id') id: string) {
+  async deleteService(
+    @Param('id') id: string,
+  ): Promise<{ status: string; data: ServiceInterface }> {
     return this.servicesService.deleteService(id);
   }
-  
 }

--- a/src/services/services.service.spec.ts
+++ b/src/services/services.service.spec.ts
@@ -56,7 +56,7 @@ describe('ServicesService', () => {
   });
 
   describe('getAllServices', () => {
-    it('should return all services', async () => {
+    it('should return all services in a jsend success object', async () => {
       // Mock the return value of serviceModel.find()
       const mockServices = [{ service_name: 'Test' }];
       serviceModel.find = jest.fn().mockReturnValue({
@@ -64,12 +64,13 @@ describe('ServicesService', () => {
       });
 
       const result = await service.getAllServices();
-      expect(result).toEqual([{ service_name: 'Test' }]);
+      expect(result.status).toBe('success');
+      expect(result.data).toBeInstanceOf(Array);
     });
   });
 
   describe('createService', () => {
-    it('should create a service', async () => {
+    it('should create a service and return a jsend object', async () => {
       // Mock the service provider
       const mockProvider = { services: [], save: jest.fn() };
       serviceProviderModel.findById.mockResolvedValue(mockProvider);
@@ -80,7 +81,10 @@ describe('ServicesService', () => {
       // Mock the serviceModel constructor to return an instance with a save method
       const mockServiceInstance = {
         save: jest.fn().mockResolvedValue({
-          toObject: jest.fn().mockReturnValue({ service_name: 'Test Created' }),
+          toObject: jest.fn().mockReturnValue({
+            _id: 'mockCreatedId',
+            service_name: 'Test Created',
+          }),
         }),
       };
       serviceModel.mockImplementation(() => mockServiceInstance);
@@ -90,7 +94,8 @@ describe('ServicesService', () => {
 
       const result = await service.createService(dto, files);
 
-      expect(result).toEqual({ service_name: 'Test Created' });
+      expect(result.status).toBe('success');
+      expect(result.data).toHaveProperty('_id');
       expect(mockProvider.save).toHaveBeenCalled();
       expect(mockServiceInstance.save).toHaveBeenCalled();
     });
@@ -106,12 +111,15 @@ describe('ServicesService', () => {
   });
 
   describe('deleteService', () => {
-    it('should delete a service successfully', async () => {
+    it('should delete a service and return a jsend object', async () => {
       const mockService = {
         _id: { toString: () => 'serviceId123' },
         service_provider_id: 'providerId123',
         deleteOne: jest.fn().mockResolvedValue({}),
-        toObject: jest.fn().mockReturnValue({ service_name: 'Deleted Service' }),
+        toObject: jest.fn().mockReturnValue({
+          _id: 'serviceId123',
+          service_name: 'Deleted Service',
+        }),
       };
       serviceModel.findById = jest.fn().mockResolvedValue(mockService);
 
@@ -123,9 +131,10 @@ describe('ServicesService', () => {
       serviceProviderModel.findById.mockResolvedValue(mockProvider);
 
       const result = await service.deleteService('serviceId123');
+      expect(result.status).toBe('success');
+      expect(result.data).toHaveProperty('_id', 'serviceId123');
       expect(mockService.deleteOne).toHaveBeenCalled();
       expect(mockProvider.services).toHaveLength(0);
-      expect(result).toEqual({ service_name: 'Deleted Service' });
     });
 
     it('should throw NotFoundException if service not found', async () => {

--- a/src/services/services.service.ts
+++ b/src/services/services.service.ts
@@ -24,15 +24,15 @@ export class ServicesService {
   /**
    * @returns An array of ServiceInterface objects with serviceProviderId.
    */
-  async getAllServices(): Promise<ServiceInterface[]> {
+  async getAllServices(): Promise<{ status: string; data: ServiceInterface[] }> {
     const services = await this.serviceModel.find().exec();
-    return services;
+    return { status: 'success', data: services };
   }
 
   async createService(
     createServiceDto: CreateServiceDto,
     files: Express.Multer.File[],
-  ): Promise<ServiceInterface> {
+  ): Promise<{ status: string; data: ServiceInterface }> {
     const imageUrls = await Promise.all(
       files.map((file) => this.cloudinary.uploadFile(file)),
     );
@@ -57,14 +57,14 @@ export class ServicesService {
     await serviceProvider.save();
 
     const savedServiceObject = savedService.toObject();
-    return savedServiceObject;
+    return { status: 'success', data: savedServiceObject };
   }
   /**
    * Deletes a service by ID.
    * @param serviceId The ID of the service to delete.
    * @returns The deleted service.
    */
-  async deleteService(serviceId: string): Promise<ServiceInterface> {
+  async deleteService(serviceId: string): Promise<{ status: string; data: ServiceInterface }> {
     const service = await this.serviceModel.findById(serviceId);
     if (!service) {
       throw new NotFoundException(`Service with ID ${serviceId} not found`);
@@ -91,6 +91,6 @@ export class ServicesService {
 
     await serviceProvider.save();
     const serviceObject = service.toObject();
-    return serviceObject;
+    return { status: 'success', data: serviceObject };
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the `ServicesController` and `ServicesService` to return responses in a standardized jsend format. The changes also include updates to the corresponding test files to reflect this new response structure.

### Changes to response structure:
* [`src/services/services.controller.ts`](diffhunk://#diff-b810d43c98d3e408f966ac036fac60756db5e659e05d9319bb85576d2c8b69ccL1-L40): Updated `getAllServices`, `createService`, and `deleteService` methods to return responses in jsend format.
* [`src/services/services.service.ts`](diffhunk://#diff-4a3644bf4fb1328d869b6da5401287c687351cec52210d61d8d7a40c9fa8848fL27-R35): Modified `getAllServices`, `createService`, and `deleteService` methods to return responses in jsend format. [[1]](diffhunk://#diff-4a3644bf4fb1328d869b6da5401287c687351cec52210d61d8d7a40c9fa8848fL27-R35) [[2]](diffhunk://#diff-4a3644bf4fb1328d869b6da5401287c687351cec52210d61d8d7a40c9fa8848fL60-R67) [[3]](diffhunk://#diff-4a3644bf4fb1328d869b6da5401287c687351cec52210d61d8d7a40c9fa8848fL94-R94)

### Updates to test files:
* [`src/services/services.controller.spec.ts`](diffhunk://#diff-f20465ffd271685b5c9141cadfe218e705a2335e4a139c86e60055d55e92fde6L51-R58): Updated tests to expect responses in jsend format for `getAllServices`, `createService`, and `deleteService` methods. [[1]](diffhunk://#diff-f20465ffd271685b5c9141cadfe218e705a2335e4a139c86e60055d55e92fde6L51-R58) [[2]](diffhunk://#diff-f20465ffd271685b5c9141cadfe218e705a2335e4a139c86e60055d55e92fde6L72-R82) [[3]](diffhunk://#diff-f20465ffd271685b5c9141cadfe218e705a2335e4a139c86e60055d55e92fde6L91-R105)
* [`src/services/services.service.spec.ts`](diffhunk://#diff-b1387c85a202ed15b2f9d108c549d428825ff385169a210b9b058583f75fb9f8L59-R73): Updated tests to expect responses in jsend format for `getAllServices`, `createService`, and `deleteService` methods. [[1]](diffhunk://#diff-b1387c85a202ed15b2f9d108c549d428825ff385169a210b9b058583f75fb9f8L59-R73) [[2]](diffhunk://#diff-b1387c85a202ed15b2f9d108c549d428825ff385169a210b9b058583f75fb9f8L83-R87) [[3]](diffhunk://#diff-b1387c85a202ed15b2f9d108c549d428825ff385169a210b9b058583f75fb9f8L93-R98) [[4]](diffhunk://#diff-b1387c85a202ed15b2f9d108c549d428825ff385169a210b9b058583f75fb9f8L109-R122) [[5]](diffhunk://#diff-b1387c85a202ed15b2f9d108c549d428825ff385169a210b9b058583f75fb9f8R134-L128)…ler and service methods