### PR TITLE
Remove required validation for confirm_password in User schema

### DIFF
--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -18,7 +18,7 @@ export class User extends Document {
   @Prop({ required: true })
   password: string;
 
-  @Prop({ required: true })
+  @Prop()
   confirm_password: string;
 
   @Prop()


### PR DESCRIPTION
This pull request includes a small change to the `src/users/schemas/user.schema.ts` file. The change removes the requirement for the `confirm_password` field to be mandatory.

* [`src/users/schemas/user.schema.ts`](diffhunk://#diff-393b47f47d6aea92fdf52734ba4efb76143e32c272ff9d0c462f58a8466d4f5dL21-R21): The `@Prop` decorator for the `confirm_password` field has been modified to remove the `required: true` attribute.