### PR TITLE
Feat/logout

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,8 +2,10 @@ import {
   Controller,
   Post,
   Body,
+  UnauthorizedException,
+  Headers,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { CreateCustomerDto } from './../users/dto/create-customer.dto';
 import { CreateServiceProviderDto } from './../users/dto/create-service-provider.dto';
@@ -17,15 +19,23 @@ export class AuthController {
 
   @Post('register/customer')
   @ApiOperation({ summary: 'Register a new customer' })
-  @ApiResponse({ status: 201, description: 'Customer registered successfully.' })
+  @ApiResponse({
+    status: 201,
+    description: 'Customer registered successfully.',
+  })
   async registerCustomer(@Body() createCustomerDto: CreateCustomerDto) {
     return this.authService.registerCustomer(createCustomerDto);
   }
 
   @Post('register/service-provider')
   @ApiOperation({ summary: 'Register a new service provider' })
-  @ApiResponse({ status: 201, description: 'Service provider registered successfully.' })
-  async registerServiceProvider(@Body() createServiceProviderDto: CreateServiceProviderDto) {
+  @ApiResponse({
+    status: 201,
+    description: 'Service provider registered successfully.',
+  })
+  async registerServiceProvider(
+    @Body() createServiceProviderDto: CreateServiceProviderDto,
+  ) {
     return this.authService.registerServiceProvider(createServiceProviderDto);
   }
 
@@ -34,6 +44,19 @@ export class AuthController {
   @ApiResponse({ status: 200, description: 'User logged in successfully.' })
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
+  }
+
+  @Post('logout')
+  @ApiOperation({ summary: 'Logout user' })
+  @ApiBearerAuth('access-token')
+  @ApiResponse({ status: 200, description: 'Successfully logged out' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async logout(@Headers('authorization') authorization: string) {
+    if (!authorization || !authorization.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Invalid authorization header');
+    }
+    const token = authorization.split(' ')[1];
+    return this.authService.logout(token);
   }
 
   @Post('refresh')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable,UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { UsersService } from './../users/users.service';
@@ -6,7 +6,6 @@ import { CreateCustomerDto } from './../users/dto/create-customer.dto';
 import { CreateServiceProviderDto } from './../users/dto/create-service-provider.dto';
 import { RefreshTokensService } from './refresh-token.service';
 import { JwtPayload } from './interfaces/jwt-payload.interface';
-
 
 @Injectable()
 export class AuthService {
@@ -179,5 +178,21 @@ export class AuthService {
         user: user._doc,
       },
     };
+  }
+
+  async logout(accessToken: string) {
+    try {
+      const payload = this.jwtService.verify(accessToken, {
+        secret: process.env.JWT_SECRET,
+        ignoreExpiration: true,
+      });
+      await this.refreshTokenService.invalidateRefreshTokens(payload.sub);
+      return {
+        status: 'success',
+        message: 'Successfully logged out',
+      };
+    } catch (error) {
+      throw new UnauthorizedException('Invalid token');
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,17 @@ async function bootstrap() {
       'We hope that this API documentation will help you understand the Service Sphere API and not wonder why does life even matter.',
     )
     .setVersion('1.0')
+    .addBearerAuth(
+      { 
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'Authorization',
+        description: 'Enter JWT token',
+        in: 'header'
+      },
+      'access-token'
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);


### PR DESCRIPTION
This pull request introduces several important changes to the authentication module, including the addition of a logout feature, modifications to existing methods, and enhancements to the Swagger documentation. Here are the most significant changes:

### New Features:
* Added a `logout` method to the `AuthController` and `AuthService` to handle user logout functionality. This includes validating the authorization header, extracting the token, and invalidating refresh tokens. [[1]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R49-R61) [[2]](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR182-R197)

### Testing Enhancements:
* Updated `auth.controller.spec.ts` to include tests for the new `logout` method, ensuring it handles various scenarios such as successful logout, missing Bearer prefix, empty authorization header, and error propagation.
* Added a new test suite for `logout` in `auth.service.spec.ts` to verify token validation and refresh token invalidation.

### Code Formatting:
* Improved code readability by formatting method calls and object properties in `auth.controller.spec.ts` and `auth.controller.ts`. [[1]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL59-R63) [[2]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL92-R102) [[3]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9L20-R38)

### Documentation:
* Enhanced Swagger documentation to include the new logout endpoint and added Bearer authentication support. [[1]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R5-R8) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR26-R36)

### Error Handling:
* Imported `UnauthorizedException` in `auth.controller.ts` and `auth.controller.spec.ts` to handle invalid authorization headers and token verification failures. [[1]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fR2) [[2]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R5-R8)