### PR TITLE
Feat/password reset

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,14 +9,27 @@ import { RolesGuard } from './guards/roles.guard';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { RefreshTokensService } from './refresh-token.service';
-import { RefreshToken, RefreshTokenSchema } from './schemas/refresh-token.schema';
+import {
+  RefreshToken,
+  RefreshTokenSchema,
+} from './schemas/refresh-token.schema';
+
+import {
+  PasswordResetToken,
+  PasswordResetTokenSchema,
+} from './schemas/password-reset-token.schema';
+
+import { PasswordResetTokensService } from './password-reset-token.service';
 
 @Module({
   imports: [
     UserModule,
     PassportModule,
     ConfigModule,
-    MongooseModule.forFeature([{ name: RefreshToken.name, schema: RefreshTokenSchema }]),
+    MongooseModule.forFeature([
+      { name: RefreshToken.name, schema: RefreshTokenSchema },
+      { name: PasswordResetToken.name, schema: PasswordResetTokenSchema },
+    ]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -26,7 +39,13 @@ import { RefreshToken, RefreshTokenSchema } from './schemas/refresh-token.schema
       }),
     }),
   ],
-  providers: [AuthService, JwtStrategy, RolesGuard, RefreshTokensService],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    RolesGuard,
+    RefreshTokensService,
+    PasswordResetTokensService,
+  ],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,22 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
 import { AuthService } from './auth.service';
 import { UsersService } from './../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { RefreshTokensService } from './refresh-token.service';
-import { UnauthorizedException } from '@nestjs/common';
-import * as bcrypt from 'bcrypt';
+import { PasswordResetTokensService } from './password-reset-token.service';
+import { UnauthorizedException, NotFoundException } from '@nestjs/common';
 
 describe('AuthService', () => {
   let authService: AuthService;
   let usersService: Partial<UsersService>;
   let jwtService: Partial<JwtService>;
   let refreshTokensService: Partial<RefreshTokensService>;
+  let passwordResetTokensService: Partial<PasswordResetTokensService>;
 
   beforeEach(async () => {
     usersService = {
       findByEmail: jest.fn(),
       createCustomer: jest.fn(),
       createServiceProvider: jest.fn(),
+      findById: jest.fn(),
+      updatePassword: jest.fn(),
     };
 
     jwtService = {
@@ -27,6 +32,14 @@ describe('AuthService', () => {
     refreshTokensService = {
       storeRefreshToken: jest.fn(),
       validateRefreshToken: jest.fn(),
+      invalidateRefreshTokens: jest.fn(),
+    };
+
+    passwordResetTokensService = {
+      deleteAllTokensForUser: jest.fn(),
+      createToken: jest.fn(),
+      findByToken: jest.fn(),
+      deleteToken: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -35,6 +48,10 @@ describe('AuthService', () => {
         { provide: UsersService, useValue: usersService },
         { provide: JwtService, useValue: jwtService },
         { provide: RefreshTokensService, useValue: refreshTokensService },
+        {
+          provide: PasswordResetTokensService,
+          useValue: passwordResetTokensService,
+        },
       ],
     }).compile();
 
@@ -74,7 +91,9 @@ describe('AuthService', () => {
         last_name: 'Doe',
         role: 'customer',
       };
-      (usersService.createCustomer as jest.Mock).mockResolvedValue(fakeCustomer);
+      (usersService.createCustomer as jest.Mock).mockResolvedValue(
+        fakeCustomer,
+      );
 
       const result = await authService.registerCustomer(createCustomerDto);
       expect(result).toEqual({
@@ -85,7 +104,9 @@ describe('AuthService', () => {
 
     it('should return error if create customer fails', async () => {
       (usersService.findByEmail as jest.Mock).mockResolvedValue(null);
-      (usersService.createCustomer as jest.Mock).mockRejectedValue(new Error('DB error'));
+      (usersService.createCustomer as jest.Mock).mockRejectedValue(
+        new Error('DB error'),
+      );
       const result = await authService.registerCustomer(createCustomerDto);
       expect(result).toEqual({
         status: 'error',
@@ -115,7 +136,9 @@ describe('AuthService', () => {
         last_name: 'User',
         role: 'service_provider',
       });
-      const result = await authService.registerServiceProvider(createServiceProviderDto);
+      const result = await authService.registerServiceProvider(
+        createServiceProviderDto,
+      );
       expect(result).toEqual({
         status: 'fail',
         data: { email: 'Email already exists' },
@@ -134,9 +157,13 @@ describe('AuthService', () => {
         tax_id: 'TAX123456',
         role: 'service_provider',
       };
-      (usersService.createServiceProvider as jest.Mock).mockResolvedValue(fakeServiceProvider);
+      (usersService.createServiceProvider as jest.Mock).mockResolvedValue(
+        fakeServiceProvider,
+      );
 
-      const result = await authService.registerServiceProvider(createServiceProviderDto);
+      const result = await authService.registerServiceProvider(
+        createServiceProviderDto,
+      );
       expect(result).toEqual({
         status: 'success',
         data: fakeServiceProvider,
@@ -145,8 +172,12 @@ describe('AuthService', () => {
 
     it('should return error if create service provider fails', async () => {
       (usersService.findByEmail as jest.Mock).mockResolvedValue(null);
-      (usersService.createServiceProvider as jest.Mock).mockRejectedValue(new Error('DB error'));
-      const result = await authService.registerServiceProvider(createServiceProviderDto);
+      (usersService.createServiceProvider as jest.Mock).mockRejectedValue(
+        new Error('DB error'),
+      );
+      const result = await authService.registerServiceProvider(
+        createServiceProviderDto,
+      );
       expect(result).toEqual({
         status: 'error',
         message: 'Failed to create service provider',
@@ -157,10 +188,10 @@ describe('AuthService', () => {
 
   describe('login', () => {
     const loginDto = { email: 'customer@example.com', password: 'password123' };
-      const fakeUser = {
+    const fakeUser = {
       _id: '1',
       email: 'customer@example.com',
-      password: 'hashedPass', 
+      password: 'hashedPass',
       first_name: 'John',
       last_name: 'Doe',
       role: 'customer',
@@ -173,17 +204,17 @@ describe('AuthService', () => {
         role: 'customer',
       },
     };
-  
+
     beforeEach(() => {
       jest.spyOn(bcrypt, 'compare').mockImplementation((pass, hash) => {
         return Promise.resolve(pass === 'password123' && hash === 'hashedPass');
       });
     });
-  
+
     afterEach(() => {
       jest.clearAllMocks();
     });
-  
+
     it('should return tokens and user data for valid credentials', async () => {
       (usersService.findByEmail as jest.Mock).mockResolvedValue(fakeUser);
       const userData = {
@@ -205,7 +236,6 @@ describe('AuthService', () => {
       expect(result.data.user).toMatchObject(userData);
     });
   });
-  
 
   describe('refreshToken', () => {
     const refreshTokenStr = 'refresh_token';
@@ -236,15 +266,22 @@ describe('AuthService', () => {
     });
 
     it('should throw UnauthorizedException if token type is invalid', async () => {
-      (jwtService.verify as jest.Mock).mockReturnValue({ ...fakePayload, type: 'access' });
+      (jwtService.verify as jest.Mock).mockReturnValue({
+        ...fakePayload,
+        type: 'access',
+      });
       await expect(authService.refreshToken(refreshTokenStr)).rejects.toThrow(
         UnauthorizedException,
       );
     });
 
     it('should throw UnauthorizedException if refresh token validation fails', async () => {
-      (refreshTokensService.validateRefreshToken as jest.Mock).mockRejectedValue(new Error('invalid'));
-      await expect(authService.refreshToken(refreshTokenStr)).rejects.toThrow(UnauthorizedException);
+      (
+        refreshTokensService.validateRefreshToken as jest.Mock
+      ).mockRejectedValue(new Error('invalid'));
+      await expect(authService.refreshToken(refreshTokenStr)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
 
     it('should return new tokens on valid refresh token', async () => {
@@ -257,10 +294,10 @@ describe('AuthService', () => {
     const validAccessToken = 'valid_access_token';
     const invalidAccessToken = 'invalid_access_token';
     const userId = 'user123';
-  
+
     beforeEach(() => {
       refreshTokensService.invalidateRefreshTokens = jest.fn();
-  
+
       (jwtService.verify as jest.Mock).mockImplementation((token, options) => {
         if (token === validAccessToken) {
           return { sub: userId };
@@ -268,38 +305,168 @@ describe('AuthService', () => {
         throw new Error('Invalid token');
       });
     });
-  
+
     it('should invalidate refresh tokens with valid access token', async () => {
       const result = await authService.logout(validAccessToken);
-      
+
       expect(jwtService.verify).toHaveBeenCalledWith(validAccessToken, {
         secret: process.env.JWT_SECRET,
         ignoreExpiration: true,
       });
-      expect(refreshTokensService.invalidateRefreshTokens).toHaveBeenCalledWith(userId);
+      expect(refreshTokensService.invalidateRefreshTokens).toHaveBeenCalledWith(
+        userId,
+      );
       expect(result).toEqual({
         status: 'success',
-        message: 'Successfully logged out'
+        message: 'Successfully logged out',
       });
     });
-  
+
     it('should throw UnauthorizedException for invalid token', async () => {
-      await expect(authService.logout(invalidAccessToken))
-        .rejects.toThrow(UnauthorizedException);
+      await expect(authService.logout(invalidAccessToken)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
-  
+
     it('should handle token verification failure', async () => {
       (jwtService.verify as jest.Mock).mockImplementationOnce(() => {
         throw new Error('Token expired');
       });
-  
-      await expect(authService.logout(validAccessToken))
-        .rejects.toThrow(UnauthorizedException);
+
+      await expect(authService.logout(validAccessToken)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
-  
+
     it('should call invalidateRefreshTokens with correct user ID', async () => {
       await authService.logout(validAccessToken);
-      expect(refreshTokensService.invalidateRefreshTokens).toHaveBeenCalledWith(userId);
+      expect(refreshTokensService.invalidateRefreshTokens).toHaveBeenCalledWith(
+        userId,
+      );
+    });
+  });
+
+  describe('generatePasswordResetToken', () => {
+    const email = 'user@example.com';
+    const user = {
+      _id: '123',
+      email,
+      toString: () => '123',
+    };
+
+    it('should throw NotFoundException if user not found', async () => {
+      (usersService.findByEmail as jest.Mock).mockResolvedValue(null);
+      await expect(
+        authService.generatePasswordResetToken(email),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should delete existing tokens and create new one', async () => {
+      (usersService.findByEmail as jest.Mock).mockResolvedValue(user);
+      (passwordResetTokensService.createToken as jest.Mock).mockResolvedValue(
+        {},
+      );
+
+      const token = await authService.generatePasswordResetToken(email);
+
+      expect(
+        passwordResetTokensService.deleteAllTokensForUser,
+      ).toHaveBeenCalledWith('123');
+      expect(passwordResetTokensService.createToken).toHaveBeenCalled();
+      expect(typeof token).toBe('string');
+      expect(token.length).toBe(40);
+    });
+  });
+
+  describe('resetPassword', () => {
+    const validToken = 'valid-token';
+    const newPassword = 'newSecurePassword123';
+    const user = {
+      _id: '123',
+      toString: () => '123',
+    };
+    const validResetToken = {
+      _id: {
+        toString: () => 'token-id', 
+      },
+      user_id: '123',
+      expires_at: new Date(Date.now() + 3600000),
+    };
+    const expiredResetToken = {
+      ...validResetToken,
+      expires_at: new Date(Date.now() - 1000),
+    };
+
+    it('should throw for invalid token', async () => {
+      (passwordResetTokensService.findByToken as jest.Mock).mockResolvedValue(
+        null,
+      );
+      await expect(
+        authService.resetPassword(validToken, newPassword),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should handle expired token', async () => {
+      (passwordResetTokensService.findByToken as jest.Mock).mockResolvedValue(
+        expiredResetToken,
+      );
+      await expect(
+        authService.resetPassword(validToken, newPassword),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(passwordResetTokensService.deleteToken).toHaveBeenCalledWith(
+        'token-id',
+      );
+    });
+
+    it('should cleanup token when user not found', async () => {
+      (passwordResetTokensService.findByToken as jest.Mock).mockResolvedValue(
+        validResetToken,
+      );
+      (usersService.findById as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        authService.resetPassword(validToken, newPassword),
+      ).rejects.toThrow(NotFoundException);
+      expect(passwordResetTokensService.deleteToken).toHaveBeenCalledWith(
+        'token-id',
+      );
+    });
+
+    it('should update password and delete token', async () => {
+      (passwordResetTokensService.findByToken as jest.Mock).mockResolvedValue(
+        validResetToken,
+      );
+      (usersService.findById as jest.Mock).mockResolvedValue(user);
+      (usersService.updatePassword as jest.Mock).mockResolvedValue(user);
+
+      const result = await authService.resetPassword(validToken, newPassword);
+
+      expect(usersService.updatePassword).toHaveBeenCalledWith(
+        '123',
+        newPassword,
+      );
+      expect(passwordResetTokensService.deleteToken).toHaveBeenCalledWith(
+        'token-id',
+      );
+      expect(result).toEqual({
+        status: 'success',
+        message: 'Password updated successfully',
+      });
+    });
+
+    it('should succeed even if token deletion fails', async () => {
+      (passwordResetTokensService.findByToken as jest.Mock).mockResolvedValue(
+        validResetToken,
+      );
+      (usersService.findById as jest.Mock).mockResolvedValue(user);
+      (passwordResetTokensService.deleteToken as jest.Mock).mockRejectedValue(
+        new Error('DB error'),
+      );
+
+      const result = await authService.resetPassword(validToken, newPassword);
+
+      expect(result.status).toBe('success');
+      expect(usersService.updatePassword).toHaveBeenCalled();
     });
   });
 });

--- a/src/auth/dto/forgot-password.dto.ts
+++ b/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,8 @@
+import { IsEmail } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ForgotPasswordDto {
+  @ApiProperty({ example: 'user@example.com' })
+  @IsEmail()
+  email: string;
+}

--- a/src/auth/dto/reset-password.dto.ts
+++ b/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResetPasswordDto {
+  @ApiProperty()
+  @IsString()
+  token: string;
+
+  @ApiProperty({ minLength: 8 })
+  @IsString()
+  @MinLength(8)
+  new_password: string;
+
+  @ApiProperty({ minLength: 8 })
+  @IsString()
+  @MinLength(8)
+  confirm_password: string;
+}

--- a/src/auth/password-reset-token.service.ts
+++ b/src/auth/password-reset-token.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
+import { PasswordResetToken } from './schemas/password-reset-token.schema';
+
+@Injectable()
+export class PasswordResetTokensService {
+  constructor(
+    @InjectModel(PasswordResetToken.name)
+    private readonly passwordResetTokenModel: Model<PasswordResetToken>,
+  ) {}
+
+  async createToken(user_id: string, token: string, expires_at: Date) {
+    await this.passwordResetTokenModel.create({
+      user_id,
+      token,
+      expires_at,
+    });
+  }
+
+  async findByToken(token: string) {
+    return this.passwordResetTokenModel.findOne({ token }).exec();
+  }
+
+  async deleteToken(id: string) {
+    await this.passwordResetTokenModel.findByIdAndDelete(id).exec();
+  }
+
+  async deleteAllTokensForUser(user_id: string) {
+    await this.passwordResetTokenModel.deleteMany({ user_id }).exec();
+  }
+}

--- a/src/auth/schemas/password-reset-token.schema.ts
+++ b/src/auth/schemas/password-reset-token.schema.ts
@@ -1,0 +1,17 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class PasswordResetToken extends Document {
+  @Prop({ required: true })
+  user_id: string;
+
+  @Prop({ required: true, unique: true })
+  token: string;
+
+  @Prop({ required: true })
+  expires_at: Date;
+}
+
+export const PasswordResetTokenSchema =
+  SchemaFactory.createForClass(PasswordResetToken);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
+import * as bcrypt from 'bcrypt';
 import { Model } from 'mongoose';
 import { CreateCustomerDto } from './dto/create-customer.dto';
 import { CreateServiceProviderDto } from './dto/create-service-provider.dto';
@@ -13,15 +14,32 @@ export class UsersService {
     return this.userModel.findOne({ email }).exec();
   }
 
+  async findById(userId: string): Promise<User | null> {
+    return this.userModel.findById(userId).exec();
+  }
+
   async createCustomer(createCustomerDto: CreateCustomerDto): Promise<User> {
-    const createdCustomer = new this.userModel({ ...createCustomerDto, role: 'customer' });
+    const createdCustomer = new this.userModel({
+      ...createCustomerDto,
+      role: 'customer',
+    });
     return createdCustomer.save();
   }
 
-  async createServiceProvider(createServiceProviderDto: CreateServiceProviderDto): Promise<User> {
-    const createdServiceProvider = new this.userModel({ ...createServiceProviderDto, role: 'service_provider' });
+  async createServiceProvider(
+    createServiceProviderDto: CreateServiceProviderDto,
+  ): Promise<User> {
+    const createdServiceProvider = new this.userModel({
+      ...createServiceProviderDto,
+      role: 'service_provider',
+    });
     return createdServiceProvider.save();
   }
 
-
+  async updatePassword(userId: string, newPassword: string): Promise<User> {
+    const hashedPassword = await bcrypt.hash(newPassword, 10);
+    return this.userModel
+      .findByIdAndUpdate(userId, { password: hashedPassword }, { new: true })
+      .exec();
+  }
 }


### PR DESCRIPTION
This pull request introduces significant changes to the authentication module, primarily focused on adding functionality for password reset. The changes include modifications to the `AuthController`, `AuthService`, and the addition of new DTOs and a service for handling password reset tokens. The most important changes are summarized below:

### Enhancements to Authentication Functionality:

* **Password Reset Endpoints**:
  - Added `forgotPassword` and `resetPassword` endpoints to `AuthController` for generating and using password reset tokens (`src/auth/auth.controller.ts`).

* **Password Reset Token Service**:
  - Introduced `PasswordResetTokensService` for creating, finding, and deleting password reset tokens (`src/auth/password-reset-token.service.ts`).

* **DTOs for Password Reset**:
  - Added `ForgotPasswordDto` and `ResetPasswordDto` to handle input validation for the new endpoints (`src/auth/dto/forgot-password.dto.ts`, `src/auth/dto/reset-password.dto.ts`). [[1]](diffhunk://#diff-4610ace679207860a1025d71e7d8d262147b66c4f0d4655bdd00f17f6ab05fc0R1-R8) [[2]](diffhunk://#diff-ee3951421db9ed0e8bbc4d81c6ae17ab2cd5f489ba3794b9b7902f840ef8f6e6R1-R18)

### Modifications to Existing Services and Tests:

* **AuthService Enhancements**:
  - Implemented methods `generatePasswordResetToken` and `resetPassword` in `AuthService` to support the new password reset functionality (`src/auth/auth.service.ts`).

* **Unit Tests**:
  - Updated `auth.service.spec.ts` to include tests for the new password reset methods, ensuring robust coverage for the new functionality (`src/auth/auth.service.spec.ts`).

These changes collectively enhance the authentication module by providing a secure and user-friendly way to handle password resets.