### PR TITLE
Refactor service creation to use user ID from request instead of serv…

### DIFF
--- a/src/services/dto/create-service.dto.ts
+++ b/src/services/dto/create-service.dto.ts
@@ -49,8 +49,4 @@ export class CreateServiceDto {
   @IsOptional()
   @IsArray()
   images?: Express.Multer.File[];
-
-  @ApiProperty({ example: '6794d963db9ce9d9caa11260' })
-  @IsString()
-  service_provider_id: string;
 }

--- a/src/services/services.controller.ts
+++ b/src/services/services.controller.ts
@@ -8,7 +8,8 @@ import {
   Param,
   Delete,
   Patch,
-  UseGuards
+  UseGuards,
+  Request,
 } from '@nestjs/common';
 import { ServicesService } from './services.service';
 import {
@@ -16,7 +17,7 @@ import {
   ApiOperation,
   ApiResponse,
   ApiConsumes,
-  ApiBearerAuth
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { ServiceDto } from './dto/service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
@@ -27,7 +28,6 @@ import { FilesInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from './../auth/guards/jwt-auth.guard';
 import { Roles } from './../common/decorators/roles.decorators';
 import { RolesGuard } from './../auth/guards/roles.guard';
-
 
 @ApiTags('Services')
 @Controller('services')
@@ -52,12 +52,17 @@ export class ServicesController {
   })
   @ApiBearerAuth('access-token')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('admin','service_provider')
+  @Roles('admin', 'service_provider')
   async createService(
     @Body() createServiceDto: CreateServiceDto,
     @UploadedFiles() files: Express.Multer.File[],
+    @Request() req: any, // add request to get user
   ): Promise<ServiceInterface> {
-    return this.servicesService.createService(createServiceDto, files);
+    return this.servicesService.createService(
+      createServiceDto,
+      files,
+      req.user.user_id,
+    );
   }
 
   @ApiOperation({ summary: 'Delete a service by Id' })
@@ -67,11 +72,9 @@ export class ServicesController {
   })
   @ApiBearerAuth('access-token')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('admin','service_provider')
+  @Roles('admin', 'service_provider')
   @Delete(':id')
-  async deleteService(
-    @Param('id') id: string,
-  ): Promise<ServiceInterface> {
+  async deleteService(@Param('id') id: string): Promise<ServiceInterface> {
     return this.servicesService.deleteService(id);
   }
 
@@ -79,7 +82,7 @@ export class ServicesController {
   @ApiConsumes('multipart/form-data')
   @ApiBearerAuth('access-token')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('admin','service_provider')
+  @Roles('admin', 'service_provider')
   @UseInterceptors(FilesInterceptor('images'))
   async updateService(
     @Param('id') id: string,

--- a/src/services/services.service.ts
+++ b/src/services/services.service.ts
@@ -33,22 +33,22 @@ export class ServicesService {
   async createService(
     createServiceDto: CreateServiceDto,
     files: Express.Multer.File[],
+    userId: string,
   ): Promise<ServiceInterface> {
     const imageUrls = await Promise.all(
       files.map((file) => this.cloudinary.uploadFile(file)),
     );
-    const { service_provider_id, ...serviceData } = createServiceDto;
-    const serviceProvider =
-      await this.serviceProviderModel.findById(service_provider_id);
+    const { ...serviceData } = createServiceDto;
+    const serviceProvider = await this.serviceProviderModel.findById(userId);
     if (!serviceProvider) {
       throw new NotFoundException(
-        `Service Provider with ID ${service_provider_id} not found`,
+        `Service Provider with ID ${userId} not found`,
       );
     }
 
     const newService = new this.serviceModel({
       ...serviceData,
-      service_provider_id: service_provider_id,
+      service_provider_id: userId,
       images: imageUrls.map((image) => image.url),
     });
 
@@ -65,9 +65,7 @@ export class ServicesService {
    * @param serviceId The ID of the service to delete.
    * @returns The deleted service.
    */
-  async deleteService(
-    serviceId: string,
-  ): Promise<ServiceInterface> {
+  async deleteService(serviceId: string): Promise<ServiceInterface> {
     const service = await this.serviceModel.findById(serviceId);
     if (!service) {
       throw new NotFoundException(`Service with ID ${serviceId} not found`);
@@ -118,8 +116,7 @@ export class ServicesService {
       const uploadResults = await Promise.all(
         files.map((file) => this.cloudinary.uploadFile(file)),
       );
-      imageUrls = uploadResults
-        .map((result) => ({ url: result.url }));
+      imageUrls = uploadResults.map((result) => ({ url: result.url }));
     }
 
     const { images, ...restUpdateServiceDto } = updateServiceDto;


### PR DESCRIPTION
This pull request includes several changes to the `services` module, focusing on refactoring the service creation and deletion logic, as well as updating the controller to handle user information. The most important changes are summarized below:

### Refactoring service creation and deletion logic:

* Removed the `service_provider_id` property from the `CreateServiceDto` class and updated the `createService` method in `ServicesService` to use the `userId` parameter instead. (`src/services/dto/create-service.dto.ts`, `src/services/services.service.ts`) [[1]](diffhunk://#diff-b70e7902fa981aaac15c44ba4b31d94d79862e5672fbe8a16ea4168cc0bd43cbL52-L55) [[2]](diffhunk://#diff-4a3644bf4fb1328d869b6da5401287c687351cec52210d61d8d7a40c9fa8848fR36-R51)
* Simplified the `deleteService` method in `ServicesService` by removing unnecessary line breaks and parameters. (`src/services/services.service.ts`)

### Updating controller to handle user information:

* Added the `Request` decorator to the `createService` method in `ServicesController` to pass the user ID from the request object. (`src/services/services.controller.ts`)
* Updated the `createService` method in `ServicesController` to pass the user ID to the service layer. (`src/services/services.controller.ts`)

### Minor code improvements:

* Added missing commas in import statements for better code consistency. (`src/services/services.controller.ts`)
* Removed an unnecessary blank line in the `ServicesController` class. (`src/services/services.controller.ts`)…ice provider ID