### PR TITLE
Optimize Dockerfile by using a slim Node.js image and adjusting file …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,11 @@ COPY . .
 RUN yarn build
 
 # Stage 2: Production
-FROM node:22
+FROM node:22-slim
 WORKDIR /usr/src/app
-# Install build dependencies
-RUN apt-get update && apt-get install -y python3 make g++
 COPY package.json yarn.lock ./
-# Install production dependencies
 RUN yarn install --production
-# Copy built files from builder stage
 COPY --from=builder /usr/src/app/dist ./dist
-# Copy environment files (needed for JWT secret)
-COPY .env* ./
+COPY --from=builder /usr/src/app/src/mail/templates ./dist/mail/templates
 EXPOSE 3000
 CMD ["yarn", "start:prod"]


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to optimize the production image and adjust the copying of necessary files. The most important changes include switching to a slimmer base image and modifying the files copied into the production image.

Optimizations to production image:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10-R15): Changed the base image from `node:22` to `node:22-slim` to reduce the image size.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10-R15): Removed the installation of build dependencies (`python3`, `make`, `g++`) and the `.env*` files, which are no longer needed in the production image.

Adjustments to file copying:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10-R15): Updated the file copy instructions to include only the necessary `mail/templates` directory from the builder stage.…copy commands for production