### PR TITLE
Feat/mail service

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,7 +20,6 @@ import { User } from './../users/schemas/user.schema';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
-
 @Injectable()
 export class AuthService {
   constructor(
@@ -64,7 +63,10 @@ export class AuthService {
         );
       } catch (error) {
         console.log('Error sending email:', error);
+        customer.emailSent = false;
       }
+
+      customer.emailSent = customer.emailSent === false ? false : true;
       return customer;
     } catch (error) {
       throw new BadRequestException('Failed to create customer');
@@ -105,8 +107,11 @@ export class AuthService {
         );
       } catch (error) {
         console.log('Error sending email:', error);
+        serviceProvider.emailSent = false;
       }
 
+      serviceProvider.emailSent =
+        serviceProvider.emailSent === false ? false : true;
       return serviceProvider;
     } catch (error) {
       throw new BadRequestException('Failed to create service provider');

--- a/src/auth/otp.service.spec.ts
+++ b/src/auth/otp.service.spec.ts
@@ -1,0 +1,133 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OtpService } from './otp.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { User } from '../users/schemas/user.schema';
+
+describe('OtpService', () => {
+  let otpService: OtpService;
+  let userModel: any;
+
+  beforeEach(async () => {
+    userModel = {
+      findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+      findById: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OtpService,
+        {
+          provide: getModelToken(User.name),
+          useValue: userModel,
+        },
+      ],
+    }).compile();
+
+    otpService = module.get<OtpService>(OtpService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateOtp', () => {
+    it('should generate a 6-digit OTP', () => {
+      const otp = otpService.generateOtp();
+
+      expect(otp).toMatch(/^\d{6}$/);
+      expect(parseInt(otp)).toBeGreaterThanOrEqual(100000);
+      expect(parseInt(otp)).toBeLessThanOrEqual(999999);
+    });
+
+    it('should generate different OTPs on consecutive calls', () => {
+      // With random functions, there's a small chance they produce the same value
+      // Let's generate multiple and ensure at least one is different
+      const otps = new Set();
+      for (let i = 0; i < 5; i++) {
+        otps.add(otpService.generateOtp());
+      }
+
+      // If we have more than one unique OTP, the function is generating different values
+      expect(otps.size).toBeGreaterThan(1);
+    });
+  });
+
+  describe('saveOtp', () => {
+    it('should save OTP with expiration time to user', async () => {
+      const userId = 'user123';
+      const otp = '123456';
+
+      await otpService.saveOtp(userId, otp);
+
+      expect(userModel.findByIdAndUpdate).toHaveBeenCalledWith(userId, {
+        email_verification_otp: otp,
+        email_verification_expires: expect.any(Date),
+      });
+    });
+
+    it('should set expiration time to 15 minutes from now', async () => {
+      const userId = 'user123';
+      const otp = '123456';
+
+      // Mock Date.now for consistent testing
+      const now = new Date('2023-01-01T12:00:00Z');
+      jest.spyOn(global, 'Date').mockImplementation(() => now);
+
+      await otpService.saveOtp(userId, otp);
+
+      // Extract the expires date from the call
+      const updateCall = userModel.findByIdAndUpdate.mock.calls[0][1];
+      const expiresDate = updateCall.email_verification_expires;
+
+      // Check that it's 15 minutes later (with some tolerance for test execution time)
+      const expectedExpires = new Date('2023-01-01T12:15:00Z');
+      expect(expiresDate.getTime()).toBeCloseTo(expectedExpires.getTime(), -2); // -2 means tolerance of 100ms
+
+      // Restore original Date implementation
+      jest.spyOn(global, 'Date').mockRestore();
+    });
+  });
+
+  describe('validateOtp', () => {
+    it('should return false if user not found', async () => {
+      userModel.findById.mockResolvedValue(null);
+
+      const result = await otpService.validateOtp('user123', '123456');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if OTP does not match', async () => {
+      userModel.findById.mockResolvedValue({
+        email_verification_otp: '654321',
+        email_verification_expires: new Date(Date.now() + 1000 * 60 * 15), // 15 min in future
+      });
+
+      const result = await otpService.validateOtp('user123', '123456');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if OTP is expired', async () => {
+      userModel.findById.mockResolvedValue({
+        email_verification_otp: '123456',
+        email_verification_expires: new Date(Date.now() - 1000), // 1 second in past
+      });
+
+      const result = await otpService.validateOtp('user123', '123456');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true if OTP matches and is not expired', async () => {
+      userModel.findById.mockResolvedValue({
+        email_verification_otp: '123456',
+        email_verification_expires: new Date(Date.now() + 1000 * 60 * 15), // 15 min in future
+      });
+
+      const result = await otpService.validateOtp('user123', '123456');
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -3,33 +3,44 @@ import { MailerModule } from '@nestjs-modules/mailer';
 import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
 import { join } from 'path';
 import { MailService } from './mail.service';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
     MailerModule.forRootAsync({
-      useFactory: async () => ({
-        transport: {
-          host: process.env.MAIL_HOST,
-          port: parseInt(process.env.MAIL_PORT, 10) || 587,
-          secure: false,
-          auth: {
-            user: process.env.MAIL_USER,
-            pass: process.env.MAIL_PASSWORD,
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => {
+        const port = configService.get<number>('MAIL_PORT') || 587;
+        const secure = port === 465; // true for 465, false for other ports
+
+        return {
+          transport: {
+            host: configService.get('MAIL_HOST'),
+            port: port,
+            secure: secure,
+            auth: {
+              user: configService.get('MAIL_USER'),
+              pass: configService.get('MAIL_PASSWORD'),
+            },
+            // Required for Gmail
+            tls: {
+              rejectUnauthorized: false,
+            },
           },
-          timeout: 50000,
-        },
-        defaults: {
-          from: `"${process.env.MAIL_FROM_NAME}" <${process.env.MAIL_FROM_ADDRESS}>`,
-        },
-        template: {
-          dir: join(__dirname, 'templates'),
-          adapter: new HandlebarsAdapter(),
-          options: {
-            strict: true,
+          defaults: {
+            from: `"${configService.get('MAIL_FROM_NAME')}" <${configService.get('MAIL_FROM_ADDRESS')}>`,
           },
-        },
-        preview: process.env.NODE_ENV === 'development',
-      }),
+          template: {
+            dir: join(__dirname, 'templates'),
+            adapter: new HandlebarsAdapter(),
+            options: {
+              strict: true,
+            },
+          },
+          preview: configService.get('NODE_ENV') === 'development',
+        };
+      },
     }),
   ],
   providers: [MailService],

--- a/src/mail/mail.service.spec.ts
+++ b/src/mail/mail.service.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MailService } from './mail.service';
+import { MailerService } from '@nestjs-modules/mailer';
+import { Logger } from '@nestjs/common';
+
+describe('MailService', () => {
+  let mailService: MailService;
+  let mailerService: MailerService;
+
+  beforeEach(async () => {
+    const mockMailerService = {
+      sendMail: jest.fn().mockResolvedValue(true),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MailService,
+        {
+          provide: MailerService,
+          useValue: mockMailerService,
+        },
+      ],
+    }).compile();
+
+    mailService = module.get<MailService>(MailService);
+    mailerService = module.get<MailerService>(MailerService);
+
+    // Mock logger to avoid console output during tests
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('sendWelcomeEmail', () => {
+    it('should call mailerService.sendMail with correct parameters', async () => {
+      const email = 'test@example.com';
+      const name = 'Test User';
+      const otp = '123456';
+
+      process.env.URL = 'http://localhost';
+      process.env.PORT = '3000';
+
+      await mailService.sendWelcomeEmail(email, name, otp);
+
+      expect(mailerService.sendMail).toHaveBeenCalledWith({
+        to: email,
+        subject: 'Welcome to Service Sphere! Confirm Your Email',
+        template: 'welcome',
+        context: expect.objectContaining({
+          name,
+          otp,
+          verificationLink: `http://localhost:3000/api/v1/auth/verify-email/${otp}`,
+        }),
+      });
+    });
+
+    it('should handle errors when sending fails', async () => {
+      const email = 'test@example.com';
+      const name = 'Test User';
+      const otp = '123456';
+
+      const error = new Error('Failed to send email');
+      jest.spyOn(mailerService, 'sendMail').mockRejectedValue(error);
+
+      await expect(
+        mailService.sendWelcomeEmail(email, name, otp),
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('sendPasswordResetEmail', () => {
+    it('should call mailerService.sendMail with correct parameters', async () => {
+      const email = 'test@example.com';
+      const name = 'Test User';
+      const token = 'reset-token-123';
+
+      process.env.URL = 'http://localhost';
+      process.env.PORT = '3000';
+
+      await mailService.sendPasswordResetEmail(email, name, token);
+
+      expect(mailerService.sendMail).toHaveBeenCalledWith({
+        to: email,
+        subject: 'Password Reset Request',
+        template: 'password-reset',
+        context: expect.objectContaining({
+          name,
+          token,
+          resetLink: `http://localhost:3000/api/v1/auth/reset-password/${token}`,
+        }),
+      });
+    });
+
+    it('should handle errors when sending fails', async () => {
+      const email = 'test@example.com';
+      const name = 'Test User';
+      const token = 'reset-token-123';
+
+      const error = new Error('Failed to send email');
+      jest.spyOn(mailerService, 'sendMail').mockRejectedValue(error);
+
+      await expect(
+        mailService.sendPasswordResetEmail(email, name, token),
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('commonContext', () => {
+    it('should return object with common email context', () => {
+      const context = mailService['commonContext']();
+
+      expect(context).toEqual({
+        appName: 'Service Sphere',
+        supportEmail: 'support@servicesphere.com',
+        currentYear: new Date().getFullYear(),
+      });
+    });
+  });
+});

--- a/src/service-bookings/service-bookings.service.spec.ts
+++ b/src/service-bookings/service-bookings.service.spec.ts
@@ -5,6 +5,8 @@ import { BookingsService } from './service-bookings.service';
 import { ServiceBookings } from './schemas/service-booking.schema';
 import { ServicesService } from '../services/services.service';
 import { NotFoundException } from '@nestjs/common';
+import { Ticket } from '../tickets/schemas/ticket.schema';
+import { UsersService } from '../users/users.service';
 
 // Create a mock constructor for bookingModel
 const mockSave = jest.fn();
@@ -12,13 +14,23 @@ const BookingModelMock = jest.fn().mockImplementation((bookingData) => {
   return { ...bookingData, save: mockSave };
 });
 
+// Mock TicketModel with create method
+const TicketModelMock = {
+  create: jest.fn().mockResolvedValue({ _id: new Types.ObjectId() }),
+};
+
 describe('BookingsService', () => {
   let service: BookingsService;
   let bookingModel: Model<ServiceBookings>;
   let servicesService: ServicesService;
+  let usersService: UsersService;
 
   const mockServicesService = {
     getServiceById: jest.fn(),
+  };
+
+  const mockUsersService = {
+    findById: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -30,8 +42,16 @@ describe('BookingsService', () => {
           useValue: BookingModelMock,
         },
         {
+          provide: getModelToken(Ticket.name),
+          useValue: TicketModelMock,
+        },
+        {
           provide: ServicesService,
           useValue: mockServicesService,
+        },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
         },
       ],
     }).compile();
@@ -42,6 +62,7 @@ describe('BookingsService', () => {
       getModelToken(ServiceBookings.name),
     );
     servicesService = module.get<ServicesService>(ServicesService);
+    usersService = module.get<UsersService>(UsersService);
   });
 
   afterEach(() => {
@@ -55,15 +76,27 @@ describe('BookingsService', () => {
   describe('createBooking', () => {
     const serviceId = new Types.ObjectId().toString();
     const customerId = new Types.ObjectId().toString();
-    const mockService = { _id: serviceId, name: 'Test Service' };
+    const providerId = new Types.ObjectId().toString();
+    const mockService = {
+      _id: serviceId,
+      name: 'Test Service',
+      service_provider_id: providerId,
+    };
+    const mockProvider = {
+      _id: providerId,
+      name: 'Test Provider',
+    };
     const savedBooking = {
       _id: new Types.ObjectId(),
       service_id: serviceId,
       customer_id: customerId,
+      status: 'pending',
+      ticket_id: new Types.ObjectId(),
     };
 
     it('should create a booking successfully', async () => {
       mockServicesService.getServiceById.mockResolvedValue(mockService);
+      mockUsersService.findById.mockResolvedValue(mockProvider);
       mockSave.mockResolvedValue(savedBooking);
 
       const result = await service.createBooking(serviceId, customerId);
@@ -72,12 +105,24 @@ describe('BookingsService', () => {
       expect(mockServicesService.getServiceById).toHaveBeenCalledWith(
         serviceId,
       );
+      expect(mockUsersService.findById).toHaveBeenCalledWith(
+        providerId.toString(),
+      );
       // Check that the constructor was called with the correct data
       expect(BookingModelMock).toHaveBeenCalledWith({
         customer_id: customerId,
         service_id: serviceId,
+        status: 'pending',
+        ticket_id: expect.any(Types.ObjectId),
       });
       expect(mockSave).toHaveBeenCalled();
+      expect(TicketModelMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          booking_id: savedBooking._id,
+          status: 'open',
+          assigned_to: mockProvider._id,
+        }),
+      );
     });
 
     it('should throw NotFoundException when service not found', async () => {
@@ -88,13 +133,23 @@ describe('BookingsService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
+    it('should throw NotFoundException when provider not found', async () => {
+      mockServicesService.getServiceById.mockResolvedValue(mockService);
+      mockUsersService.findById.mockResolvedValue(null);
+
+      await expect(
+        service.createBooking(serviceId, customerId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
     it('should throw error when creation fails', async () => {
       mockServicesService.getServiceById.mockResolvedValue(mockService);
+      mockUsersService.findById.mockResolvedValue(mockProvider);
       mockSave.mockRejectedValue(new Error('Creation failed'));
 
       await expect(
         service.createBooking(serviceId, customerId),
-      ).rejects.toThrow('Creation failed');
+      ).rejects.toThrow('Failed to create booking');
     });
   });
 });

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -44,6 +44,9 @@ export class User extends Document {
 
   @Prop()
   email_verification_expires: Date;
+
+  @Prop({ default: true })
+  emailSent: boolean;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);


### PR DESCRIPTION
This pull request introduces several changes to the authentication service and its tests, primarily to integrate OTP (One-Time Password) functionality and improve email handling. Below are the most important changes grouped by theme:

### OTP Integration:

* [`src/auth/auth.controller.spec.ts`](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fR8-R13): Added `OtpService` and its mock implementation to the test suite. Updated the `beforeEach` setup to include `OtpService`. Added tests for the new `verifyEmail` method in `AuthController`. [[1]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fR8-R13) [[2]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fR22-R42) [[3]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL164-R227)
* [`src/auth/auth.service.spec.ts`](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35R9-R23): Added `OtpService` and its mock implementation to the test suite. Updated the `beforeEach` setup to include `OtpService`. [[1]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35R9-R23) [[2]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35R52-R80)
* [`src/auth/auth.service.ts`](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cL23): Integrated OTP generation and validation in the `registerCustomer` and `registerServiceProvider` methods. [[1]](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cL23) [[2]](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR66-R69) [[3]](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR110-R114)

### Email Handling:

* [`src/auth/auth.service.spec.ts`](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35R9-R23): Added `MailService` and its mock implementation to the test suite. Updated the `beforeEach` setup to include `MailService`. Added tests to handle email sending failures during customer registration. [[1]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35R9-R23) [[2]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L75-R167)
* [`src/auth/auth.service.ts`](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR66-R69): Modified the `registerCustomer` and `registerServiceProvider` methods to set `emailSent` to `false` if sending the email fails. [[1]](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR66-R69) [[2]](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR110-R114)

### Code Formatting:

* [`src/auth/auth.controller.spec.ts`](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL54-R69): Reformatted long lines for better readability. [[1]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL54-R69) [[2]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL84-R105) [[3]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL103-R122) [[4]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL125-R161) [[5]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL149-R185)
* [`src/auth/auth.service.spec.ts`](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L126-R193): Reformatted long lines and added comments for clarity. [[1]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L126-R193) [[2]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L159-R225) [[3]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L186-R252) [[4]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L199-R273) [[5]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L216-R282) [[6]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L233-R301) [[7]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35L255-R340)